### PR TITLE
Style ServicesSection and Add Fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,8 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/GlobalStyle.jsx
+++ b/src/components/GlobalStyle.jsx
@@ -8,7 +8,7 @@ const GlobalStyle = createGlobalStyle`
 body {
   background:#faf9f9;
   color: #333745;
-  font-family: sans-serif;
+  font-family: 'Poppins', sans-serif;
 }
 button {
   border: none;
@@ -17,12 +17,16 @@ button {
   cursor: pointer;
   font-size: 1.1rem;
   font-weight: bold;
+  margin: 1rem;
   padding: 1rem 1rem;
   transition: all 0.5s ease;
   &:hover {
     background-color:#00b4d8;
     border-radius: 10px;
   }
+}
+h1 {
+  font-family: 'Architects Daughter', cursive;
 }
 h2 {
   font-size: 4rem;

--- a/src/components/ServicesSection.jsx
+++ b/src/components/ServicesSection.jsx
@@ -1,9 +1,14 @@
 import { faCar, faCertificate, faSpa, faSmileBeam } from '@fortawesome/free-solid-svg-icons';
-import home2 from '../images/gong.jpg'
 import ServiceCard from './partials/ServiceCard';
+import home2 from '../images/gong.jpg'
+import styled from "styled-components";
+
+/**
+ * Return object
+ */
 const ServicesSection = () => {
   return (
-    <div className="services">
+    <Services>
       <div className="description">
         <h3>
           Equipment and Guidance
@@ -11,7 +16,7 @@ const ServicesSection = () => {
         <p>
           You need only bring yourself.
         </p>
-        <div className="cards">
+        <Cards>
           <ServiceCard
             icon={faCar}
             heading="Mobile"
@@ -29,10 +34,10 @@ const ServicesSection = () => {
           />
           <ServiceCard
             icon={faSmileBeam}
-            heading="Friendly, Five-Star Service"
+            heading="Five-Star Service"
             message="Our testimonials frequently mention the warm, friendly attitudes of our coaches."
           />
-        </div>
+        </Cards>
       </div>
       <figure>
         <img src={home2} alt="A person cooling some incense" />
@@ -40,8 +45,24 @@ const ServicesSection = () => {
         <span>Photo by <a href="https://unsplash.com/@madhatterzone?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Manja Vitolic</a> on <a href="https://unsplash.com/s/photos/gong?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
         </figcaption>
       </figure>
-    </div>
+    </Services>
   );
 }
+
+const Services = styled.div`
+  h3 {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+  p {
+    padding: 2rem 0rem 4rem 0rem;
+    width: 70%;
+  }
+`;
+
+const Cards = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
 
 export default ServicesSection;

--- a/src/components/partials/ServiceCard.jsx
+++ b/src/components/partials/ServiceCard.jsx
@@ -1,17 +1,36 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styled from "styled-components";
+
+/**
+ * Return object
+ */
 const ServiceCard = ({icon, heading, message}) => {
   return (
-    <div className="card">
+    <Card>
       <div className="icon">
-        <FontAwesomeIcon icon={icon} />
-        <h3>
+        <FontAwesomeIcon icon={icon} size="2x" />
+        <h4>
           {heading}
-        </h3>
-        <p>
-          {message}
-        </p>
+        </h4>
       </div>
-    </div>
+      <p>
+        {message}
+      </p>
+    </Card>
   );
 }
+
+const Card = styled.div`
+  border: 1px solid #000;
+  flex-basis: 15rem;
+  h4 {
+    margin-left: 1rem;
+    padding: 1rem;
+  }
+  .icon {
+    align-items: center;
+    display: flex;
+  }
+`;
+
 export default ServiceCard;


### PR DESCRIPTION
_I'm not really sure why you needed to put this on a dev branch so early but OK._

### Style ServicesSection

- Create `<Cards>` styled div to wrap around all `ServiceCard` components.
- Create a `<Card>` styled div for each Service Card.
- Serve them up flex style.
- Ignore when Ed uses styled component inheritance by exporting them from a JavaScript file. I don't want to do that.

### Add Fonts

- Add Poppins Google Font for all text: sans-serif.
- Add Architects Daughter Google Font for only h1: cursive.